### PR TITLE
perform watershed plane-by-plane instead of in 3D

### DIFF
--- a/gala/morpho.py
+++ b/gala/morpho.py
@@ -216,7 +216,7 @@ def watershed(a, seeds=None, connectivity=1, mask=None, smooth_thresh=0.0,
         seeds = regional_minima(a, connectivity)
     if seeds.dtype == bool:
         seeds = label(seeds, sel)[0]
-    if minimum_seed_size >= 0:
+    if minimum_seed_size > 0:
         seeds = remove_small_connected_components(seeds, minimum_seed_size,
                                                   in_place=True)
         seeds = relabel_from_one(seeds)[0]


### PR DESCRIPTION
I've added a new function to do what's described in the title. I've also taken the opportunity to update the doc on the watershed function and implement a kwarg that wasn't actually implemented
