### PR TITLE
Call python -m nose so return status is 1 on test fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,10 @@ script:
 
   # Run tests
   - cd tests
-  - python test_agglo.py
-  - python test_features.py
-  - python test_watershed.py
-  - python test_gala.py
+  - python -m nose test_agglo.py
+  - python -m nose test_features.py
+  - python -m nose test_watershed.py
+  - python -m nose test_gala.py
 
 after_success:
   # We must run coveralls from the git repo.


### PR DESCRIPTION
Travis builds were passing even when tests were failing because python test_something.py has exit status 0 regardless of the test outcome. Using python -m nose returns status 1 when tests fail.
