### PR TITLE
Add missing argument to classifier_extension function

### DIFF
--- a/gala/classify.py
+++ b/gala/classify.py
@@ -45,7 +45,7 @@ def h5py_stack(fn):
         raise
     return a
 
-def default_classifier_extension(cl):
+def default_classifier_extension(cl, use_joblib=True):
     """
     Return the default classifier file extension for the given classifier cl.
 


### PR DESCRIPTION
The function uses an undefined bool value, `use_joblib`, which results in a runtime error when running `gala-train`. This PR defines the value using a default argument.
