### PR TITLE
catch deprecated Image library import method

### DIFF
--- a/gala/imio.py
+++ b/gala/imio.py
@@ -9,7 +9,11 @@ import subprocess
 import tempfile as tmp
 
 # libraries
-import h5py, Image
+import h5py
+try:
+    import Image
+except:
+    from PIL import Image
 try:
     from pylibtiff import TIFF
 except:


### PR DESCRIPTION
This should work for both python-pillow and python-imaging
