### PR TITLE
Change PIL to pillow for better future support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.6
-PIL>=1.1.7
+pillow>=2.7.0
 networkx>=1.6
 h5py>=1.5
 scipy>=0.9


### PR DESCRIPTION
pip installing PIL was failing on RTD, causing all other requirement imports to fail. Hoping this will fix it.