### PR TITLE
Float watershed

### DIFF
--- a/gala/agglo.py
+++ b/gala/agglo.py
@@ -832,6 +832,9 @@ class Rag(Graph):
         -------
         None
         """
+        if not np.issubdtype(ws.dtype, np.integer):
+            ws = ws.astype(morpho.smallest_int_dtype(np.max(ws),
+                                                     signed=np.min(ws) < 0))
         try:
             self.boundary_body = ws.max()+1
         except ValueError: # empty watershed given

--- a/gala/agglo.py
+++ b/gala/agglo.py
@@ -812,7 +812,7 @@ class Rag(Graph):
                 self.probabilities_r[:, ~self.channel_is_oriented]
 
 
-    def set_watershed(self, ws=array([]), lowmem=False, connectivity=1):
+    def set_watershed(self, ws=array([], int), lowmem=False, connectivity=1):
         """Set the initial segmentation volume (watershed).
 
         The initial segmentation is called `watershed` for historical

--- a/gala/agglo.py
+++ b/gala/agglo.py
@@ -378,7 +378,7 @@ class Rag(Graph):
         and *two* nodes, to specify an edge that cannot be merged.
     """
 
-    def __init__(self, watershed=array([]), probabilities=array([]),
+    def __init__(self, watershed=array([], int), probabilities=array([]),
             merge_priority_function=boundary_mean,
             allow_shared_boundaries=True, gt_vol=None,
             feature_manager=features.base.Null(),

--- a/tests/test_agglo.py
+++ b/tests/test_agglo.py
@@ -30,6 +30,15 @@ def test_8_connectivity():
     assert_equal(agglo.boundary_mean(g, 1, 2), 0.75)
     assert_equal(agglo.boundary_mean(g, 1, 4), 1.0)
 
+def test_float_watershed():
+    """Ensure float arrays passed as watersheds don't crash everything."""
+    p = np.array([[0,0.5,0],[0.5,1.0,0.5],[0,0.5,0]])
+    ws = np.array([[1,0,2],[0,0,0],[3,0,4]], np.float32)
+    g = agglo.Rag(ws, p, connectivity=2)
+    assert_equal(agglo.boundary_mean(g, 1, 2), 0.75)
+    assert_equal(agglo.boundary_mean(g, 1, 4), 1.0)
+
+
 def test_empty_rag():
     g = agglo.Rag()
     assert_equal(g.nodes(), [])


### PR DESCRIPTION
Addresses [this issue](http://gala.30861.n7.nabble.com/GALA-Usage-for-2D-Images-tp58p65.html) raised on the mailing list. Even though the documentation specifies int input, this is an easy enough fix for most circumstances.