### PR TITLE
Implement @mjanusz's edge batching

### DIFF
--- a/gala/agglo.py
+++ b/gala/agglo.py
@@ -2046,7 +2046,7 @@ class Rag(Graph):
                 i, j = nodes2ind[u], nodes2ind[v]
             except KeyError:
                 continue
-            w = merge_priority_function(self,u,v)
+            w = merge_priority_function(self, ((u, v)))
             W[i,j] = W[j,i] = np.exp(-w**2/sigma)
         return W
 

--- a/gala/agglo.py
+++ b/gala/agglo.py
@@ -1534,6 +1534,7 @@ class Rag(Graph):
                 qitem = [w, True, u, v]
                 self[u][v]['qlink'] = qitem
                 self.merge_queue.push(qitem)
+                self[u][v]['weight'] = w
         node_id = self.tree.merge(n1, n2, w)
         self.remove_node(n2)
         self.rename_node(n1, node_id)

--- a/gala/agglo.py
+++ b/gala/agglo.py
@@ -1521,20 +1521,7 @@ class Rag(Graph):
             self.merge_queue.invalidate(self[n1][n2]['qlink'])
         except KeyError:  # no edge or no queue link
             pass
-        edges_to_update = [e for e in edges_to_update
-                           if self.boundary_body not in e]
-        if edges_to_update and not self.merge_queue.is_null_queue:
-            weights = self.merge_priority_function(self, edges_to_update)
-            for w, (u, v) in zip(weights, edges_to_update):
-                try:
-                    self.merge_queue.invalidate(self[u][v]['qlink'])
-                except KeyError as e:
-                    if 'qlink' not in e.args:
-                        raise e
-                qitem = [w, True, u, v]
-                self[u][v]['qlink'] = qitem
-                self.merge_queue.push(qitem)
-                self[u][v]['weight'] = w
+        self.update_merge_queue(edges_to_update)
         node_id = self.tree.merge(n1, n2, w)
         self.remove_node(n2)
         self.rename_node(n1, node_id)
@@ -1691,7 +1678,8 @@ class Rag(Graph):
         -------
         None
         """
-        if not self.merge_queue.is_null_queue:
+        edges = [e for e in edges if self.boundary_body not in e]
+        if not self.merge_queue.is_null_queue and edges:
             weights = self.merge_priority_function(self, edges)
             for w, (u, v) in zip(weights, edges):
                 if 'qlink' in self[u][v]:

--- a/gala/agglo.py
+++ b/gala/agglo.py
@@ -1521,10 +1521,19 @@ class Rag(Graph):
             self.merge_queue.invalidate(self[n1][n2]['qlink'])
         except KeyError:  # no edge or no queue link
             pass
-        if edges_to_update:
+        edges_to_update = [e for e in edges_to_update
+                           if self.boundary_body not in e]
+        if edges_to_update and not self.merge_queue.is_null_queue:
             weights = self.merge_priority_function(self, edges_to_update)
             for w, (u, v) in zip(weights, edges_to_update):
-                self.merge_queue.push([w, True, u, v])
+                try:
+                    self.merge_queue.invalidate(self[u][v]['qlink'])
+                except KeyError as e:
+                    if 'qlink' not in e.args:
+                        raise e
+                qitem = [w, True, u, v]
+                self[u][v]['qlink'] = qitem
+                self.merge_queue.push(qitem)
         node_id = self.tree.merge(n1, n2, w)
         self.remove_node(n2)
         self.rename_node(n1, node_id)

--- a/tests/test_agglo.py
+++ b/tests/test_agglo.py
@@ -59,7 +59,8 @@ def test_agglomeration():
 def test_ladder_agglomeration():
     i = 2
     g = agglo.Rag(wss[i], probs[i], agglo.boundary_mean,
-                  normalize_probabilities=True, use_slow=True)
+                  normalize_probabilities=True, use_slow=True,
+                  update_unchanged_edges=True)
     g.agglomerate_ladder(3)
     g.agglomerate(0.51)
     assert_allclose(ev.vi(g.get_segmentation(), results[i]), 0.0,
@@ -83,7 +84,7 @@ def test_mito():
                   normalize_probabilities=True, isfrozennode=frozen,
                   use_slow=True)
     g.agglomerate(0.15)
-    g.merge_priority_function = agglo.mito_merge()
+    g.merge_priority_function = agglo.mito_merge
     g.rebuild_merge_queue()
     g.agglomerate(1.0)
     assert_allclose(ev.vi(g.get_segmentation(), results[i]), 0.0,
@@ -164,13 +165,13 @@ def dummy_data():
 
 def test_manual_agglo_fast_rag(dummy_data):
     frag, gt, g = dummy_data
-    assert agglo.boundary_mean(g, [[6, 7]]) == 0.8
-    assert agglo.boundary_mean(g, [[6, 10]]) == 0.8
+    assert agglo.boundary_mean(g, [[6, 7]])[0] == 0.8
+    assert agglo.boundary_mean(g, [[6, 10]])[0] == 0.8
     original_ids_0 = [g[u][v]['boundary-ids'] for u, v in [(5, 9), (6, 10)]]
     original_ids_1 = [g[u][v]['boundary-ids'] for u, v in [(7, 11), (8, 12)]]
     original_ids_2 = [g[u][v]['boundary-ids'] for u, v in [(2, 3), (6, 7)]]
     g.merge_subgraph([1, 2, 5, 6])  # results in node ID 20
-    assert agglo.boundary_mean(g, ((20, 10))) == 0.8
+    assert agglo.boundary_mean(g, [[20, 10]])[0] == 0.8
     g.merge_subgraph(range(9, 17))
     assert g[20][27]['boundary-ids'] == set.union(*original_ids_0)
     assert np.allclose(agglo.boundary_mean(g, [[20, 27]])[0], 0.8, atol=0.02)

--- a/tests/test_agglo.py
+++ b/tests/test_agglo.py
@@ -27,16 +27,18 @@ def test_2_connectivity():
     p = np.array([[1., 0.], [0., 1.]])
     ws = np.array([[1, 2], [3, 4]], np.uint32)
     g = agglo.Rag(ws, p, connectivity=2, use_slow=True)
-    assert_equal(agglo.boundary_mean(g, 1, 2), 0.5)
-    assert_equal(agglo.boundary_mean(g, 1, 4), 1.0)
+    assert_equal(agglo.boundary_mean(g, [[1, 2]]), [0.5])
+    assert_equal(agglo.boundary_mean(g, [[1, 4]]), [1.0])
+    assert_equal(agglo.boundary_mean(g, [[1, 2], [1, 4]]), [0.5, 1.0])
 
 def test_float_watershed():
     """Ensure float arrays passed as watersheds don't crash everything."""
     p = np.array([[1., 0.], [0., 1.]])
     ws = np.array([[1, 2], [3, 4]], np.float32)
     g = agglo.Rag(ws, p, connectivity=2, use_slow=True)
-    assert_equal(agglo.boundary_mean(g, 1, 2), 0.5)
-    assert_equal(agglo.boundary_mean(g, 1, 4), 1.0)
+    assert_equal(agglo.boundary_mean(g, [[1, 2]])[0], 0.5)
+    assert_equal(agglo.boundary_mean(g, [[1, 4]])[0], 1.0)
+    assert_equal(agglo.boundary_mean(g, [[1, 2], [1, 4]]), [0.5, 1.0])
 
 
 def test_empty_rag():
@@ -162,16 +164,16 @@ def dummy_data():
 
 def test_manual_agglo_fast_rag(dummy_data):
     frag, gt, g = dummy_data
-    assert agglo.boundary_mean(g, 6, 7) == 0.8
-    assert agglo.boundary_mean(g, 6, 10) == 0.8
+    assert agglo.boundary_mean(g, [[6, 7]]) == 0.8
+    assert agglo.boundary_mean(g, [[6, 10]]) == 0.8
     original_ids_0 = [g[u][v]['boundary-ids'] for u, v in [(5, 9), (6, 10)]]
     original_ids_1 = [g[u][v]['boundary-ids'] for u, v in [(7, 11), (8, 12)]]
     original_ids_2 = [g[u][v]['boundary-ids'] for u, v in [(2, 3), (6, 7)]]
     g.merge_subgraph([1, 2, 5, 6])  # results in node ID 20
-    assert agglo.boundary_mean(g, 20, 10) == 0.8
+    assert agglo.boundary_mean(g, ((20, 10))) == 0.8
     g.merge_subgraph(range(9, 17))
     assert g[20][27]['boundary-ids'] == set.union(*original_ids_0)
-    assert np.allclose(agglo.boundary_mean(g, 20, 27), 0.8, atol=0.02)
+    assert np.allclose(agglo.boundary_mean(g, [[20, 27]])[0], 0.8, atol=0.02)
     g.merge_subgraph([3, 4, 7, 8])
     assert g[27][30]['boundary-ids'] == set.union(*original_ids_1)
     g.merge_nodes(27, 30)


### PR DESCRIPTION
Instead of calling `merge_priority_function` (usually a feature transform and a call to scikit-learn) directly as we encounter each edge, we add the edge to a batch and evaluate the function vectorized across all the accumulated edges.

This results in dramatic speedups at both learning and test-time, at no cost to memory:

```
# master
Timing results:
---  build RAG 0.399227459
---  build feature caches 1.0142317930000004
---  learn flat 6.226274373
---  learn agglo 437.25951286
---  classifier training 1.7207173679999528
---  segment test volume 135.74367634500004
Memory results:
---  base RAG 28.049 MB
---  feature caches 0.629 MB
---  training data 1.490 MB
---  classifier training 0.071 MB
---  segment test volume 27.468 MB

# batch-edges
Timing results:
---  build RAG 0.3964842690000001
---  build feature caches 1.0158853469999998
---  learn flat 6.258743795999999
---  learn agglo 79.627681051
---  classifier training 1.5787226850000025
---  segment test volume 18.391299654999997
Memory results:
---  base RAG 28.049 MB
---  feature caches 0.629 MB
---  training data 1.546 MB
---  classifier training 0.071 MB
---  segment test volume 27.607 MB
```

That's 5.5x train, 7.5x test speedup, *on top of* the speed gains from #82. 

