### PR TITLE
Fix VTK file IO

### DIFF
--- a/gala/imio.py
+++ b/gala/imio.py
@@ -321,24 +321,26 @@ def write_vtk(ar, fn, spacing=[1.0, 1.0, 1.0]):
         This function does not have a return value.
     """
     # write header
-    f = open(fn, 'w')
-    f.write('# vtk DataFile Version 3.0\n')
-    f.write('created by write_vtk (Python implementation by JNI)\n')
-    f.write('BINARY\n')
-    f.write('DATASET STRUCTURED_POINTS\n')
-    f.write(' '.join(['DIMENSIONS'] + list(map(str, ar.shape[-1::-1]))) + '\n')
-    f.write(' '.join(['ORIGIN'] + list(map(str, zeros(3)))) + '\n')
-    f.write(' '.join(['SPACING'] + list(map(str, spacing))) + '\n')
-    f.write('POINT_DATA ' + str(ar.size) + '\n')
-    f.write('SCALARS image_data ' +
-                            numpy_type_to_vtk_string[ar.dtype.type] + '\n')
-    f.write('LOOKUP_TABLE default\n');
+    f = open(fn, 'wb')
+    f.write(b'# vtk DataFile Version 3.0\n')
+    f.write(b'created by write_vtk (Python implementation by JNI)\n')
+    f.write(b'BINARY\n')
+    f.write(b'DATASET STRUCTURED_POINTS\n')
+    f.write(str.encode(' '.join(['DIMENSIONS'] +
+                                list(map(str, ar.shape[-1::-1]))) + '\n'))
+    f.write(str.encode(' '.join(['ORIGIN'] + list(map(str, zeros(3)))) + '\n'))
+    f.write(str.encode(' '.join(['SPACING'] + list(map(str, spacing))) + '\n'))
+    f.write(str.encode('POINT_DATA ' + str(ar.size) + '\n'))
+    f.write(str.encode('SCALARS image_data ' +
+                       numpy_type_to_vtk_string[ar.dtype.type] + '\n'))
+    f.write(b'LOOKUP_TABLE default\n');
     f.close()
 
     # write data as binary
     f = open(fn, 'ab')
-    f.write(ar.data)
+    f.write(ar.tobytes())
     f.close()
+
 
 def read_vtk(fin):
     """Read a numpy volume from a VTK structured points file.

--- a/gala/imio.py
+++ b/gala/imio.py
@@ -357,15 +357,15 @@ def read_vtk(fin):
     ar : numpy ndarray
         The array contained in the file.
     """
-    f = open(fin, 'r')
+    f = open(fin, 'rb')
     num_lines_in_header = 10
-    lines = [f.readline() for i in range(num_lines_in_header)]
+    lines = [bytes.decode(f.readline()) for i in range(num_lines_in_header)]
     shape_line = [line for line in lines if line.startswith('DIMENSIONS')][0]
     type_line = [line for line in lines 
         if line.startswith('SCALARS') or line.startswith('VECTORS')][0]
-    ar_shape = map(int, shape_line.rstrip('\n').split(' ')[1:])[-1::-1]
-    ar_type = vtk_string_to_numpy_type[type_line.rstrip('\n').split(' ')[2]]
-    ar = squeeze(fromstring(f.read(), ar_type).reshape(ar_shape+[-1]))
+    ar_shape = [int(b) for b in shape_line.rstrip().split(' ')[-1:0:-1]]
+    ar_type = vtk_string_to_numpy_type[type_line.rstrip().split(' ')[2]]
+    ar = np.squeeze(fromstring(f.read(), ar_type).reshape(ar_shape+[-1]))
     return ar
 
 ### HDF5 format

--- a/gala/imio.py
+++ b/gala/imio.py
@@ -365,7 +365,9 @@ def read_vtk(fin):
         if line.startswith('SCALARS') or line.startswith('VECTORS')][0]
     ar_shape = [int(b) for b in shape_line.rstrip().split(' ')[-1:0:-1]]
     ar_type = vtk_string_to_numpy_type[type_line.rstrip().split(' ')[2]]
-    ar = np.squeeze(fromstring(f.read(), ar_type).reshape(ar_shape+[-1]))
+    if type_line.startswith('VECTORS'):
+        ar_shape.append(-1)
+    ar = fromstring(f.read(), ar_type).reshape(ar_shape)
     return ar
 
 ### HDF5 format

--- a/tests/test_imio.py
+++ b/tests/test_imio.py
@@ -19,3 +19,18 @@ def test_cremi_roundtrip():
     np.testing.assert_equal(stored_resolution, (40, 4, 4))
     np.testing.assert_equal(raw_in, raw_image)
     np.testing.assert_equal(lab_in, labels)
+
+
+def test_vtk_roundtrip():
+    for i in range(4):
+        ar_shape = np.random.randint(1, 50, size=3)
+        dtypes = list(imio.numpy_type_to_vtk_string.keys())
+        cur_dtype = np.random.choice(dtypes)
+        if np.issubdtype(cur_dtype, np.integer):
+            ar = np.random.randint(0, 127, size=ar_shape).astype(cur_dtype)
+        else:
+            ar = np.random.rand(*ar_shape).astype(cur_dtype)
+        with temporary_file('.vtk') as fout:
+            imio.write_vtk(ar, fout)
+            ar_in = imio.read_vtk(fout)
+        np.testing.assert_equal(ar, ar_in)


### PR DESCRIPTION
This function was not tested so it was not verified to work in Python 3. This PR modernizes the function and adds a test to prevent regression.