### PR TITLE
Remove bug in ARE in evaluate.py

### DIFF
--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -941,6 +941,8 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
         the groundtruth to score against, where each value is a label
     all_stats : boolean, optional
         whether to also return precision and recall as a 3-tuple with rand_error
+    count_zeros : boolean, optional
+        whether to include the pixels labeled a zero in the groundtruth or not
 
     Returns
     -------

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -1008,15 +1008,6 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
     else:
         sum_b = np.power(b_i, 2).sum() + num_B_zero
 
-    # This is old code no longer required for this version of the adapted
-    # Rand error. It has been commented out.
-    # sumA = np.sum(a_i * a_i)
-    # sumB = np.sum(b_i * b_i) + (np.sum(c) / n)
-    # sumAB = np.sum(d) + (np.sum(c) / n)
-
-    # precision = sumAB / sumB
-    # recall = sumAB / sumA
-
     precision = float(sum_p_ij) / sum_b
     recall = float(sum_p_ij) / sum_a
 

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -993,6 +993,8 @@ def adapted_rand_error(seg, gt, all_stats=False):
     a_i = p_ij.sum(1)
     b_i = B_nonzero.sum(0)
 
+    sum_a = np.power(a_i, 2).sum()
+    sum_b = np.power(b_i, 2).sum() + num_B_zero
 
     sumA = np.sum(a_i * a_i)
     sumB = np.sum(b_i * b_i) + (np.sum(c) / n)

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -996,9 +996,11 @@ def adapted_rand_error(seg, gt, all_stats=False):
     sum_a = np.power(a_i, 2).sum()
     sum_b = np.power(b_i, 2).sum() + num_B_zero
 
-    sumA = np.sum(a_i * a_i)
-    sumB = np.sum(b_i * b_i) + (np.sum(c) / n)
-    sumAB = np.sum(d) + (np.sum(c) / n)
+    # This is old code no longer required for this version of the adapted
+    # Rand error. It has been commented out
+    #sumA = np.sum(a_i * a_i)
+    #sumB = np.sum(b_i * b_i) + (np.sum(c) / n)
+    #sumAB = np.sum(d) + (np.sum(c) / n)
 
     precision = sumAB / sumB
     recall = sumAB / sumA

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -985,9 +985,9 @@ def adapted_rand_error(seg, gt, all_stats=False):
     num_B_zero = B_zero.sum()
 
     # This is the new code, removing the divides by n because they cancel.
-    # sum of the joint distribution
-    #   separate sum of B>0 and B=0 parts
-    
+
+    # sum of the joint distribution ,separate sum of B>0 and B=0 parts
+    sum_p_ij = (B_nonzero).power(2).sum() + num_B_zero
 
     a = p_ij[1:n_labels_A,:]
     b = p_ij[1:n_labels_A,1:n_labels_B]

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -984,6 +984,10 @@ def adapted_rand_error(seg, gt, all_stats=False):
     # this is a count
     num_B_zero = B_zero.sum()
 
+    # This is the new code, removing the divides by n because they cancel.
+    # sum of the joint distribution
+    #   separate sum of B>0 and B=0 parts
+    
 
     a = p_ij[1:n_labels_A,:]
     b = p_ij[1:n_labels_A,1:n_labels_B]

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -978,6 +978,11 @@ def adapted_rand_error(seg, gt, all_stats=False):
     # pixel in segB as a different value (i.e., unique label for each pixel).
     # To do this, we sum them differently than others
 
+    B_nonzero = p_ij[:, 1:]
+    B_zero = p_ij[:, 0]
+
+    # this is a count
+    num_B_zero = B_zero.sum()
 
 
     a = p_ij[1:n_labels_A,:]

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -974,6 +974,12 @@ def adapted_rand_error(seg, gt, all_stats=False):
 
     p_ij = sparse.csr_matrix((ones_data, (segA[:], segB[:])), shape=(n_labels_A, n_labels_B), dtype=np.uint64)
 
+    # In the paper where adapted rand is proposed, they treat each background
+    # pixel in segB as a different value (i.e., unique label for each pixel).
+    # To do this, we sum them differently than others
+
+
+
     a = p_ij[1:n_labels_A,:]
     b = p_ij[1:n_labels_A,1:n_labels_B]
     c = p_ij[1:n_labels_A,0].todense()

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -972,7 +972,7 @@ def adapted_rand_error(seg, gt, all_stats=False):
 
     ones_data = np.ones(n)
 
-    p_ij = sparse.csr_matrix((ones_data, (segA[:], segB[:])), shape=(n_labels_A, n_labels_B))
+    p_ij = sparse.csr_matrix((ones_data, (segA[:], segB[:])), shape=(n_labels_A, n_labels_B), dtype=np.uint64)
 
     a = p_ij[1:n_labels_A,:]
     b = p_ij[1:n_labels_A,1:n_labels_B]

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -1005,7 +1005,8 @@ def adapted_rand_error(seg, gt, all_stats=False):
     #precision = sumAB / sumB
     #recall = sumAB / sumA
 
-    
+    precision = float(sum_p_ij) / sum_b
+    recall = float(sum_p_ij) / sum_a
 
     fScore = 2.0 * precision * recall / (precision + recall)
     are = 1.0 - fScore

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -951,6 +951,9 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=False):
         The adapted Rand precision. (Only returned when `all_stats` is ``True``.)
     rec : float, optional
         The adapted Rand recall.  (Only returned when `all_stats` is ``True``.)
+    count_zeros : boolean, optional
+        Formal parameter that includes the calculation of background pixels
+        labeled a zero in the ARE (disabled by default)
 
     References
     ----------

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -993,13 +993,6 @@ def adapted_rand_error(seg, gt, all_stats=False):
     a_i = p_ij.sum(1)
     b_i = B_nonzero.sum(0)
 
-    a = p_ij[1:n_labels_A,:]
-    b = p_ij[1:n_labels_A,1:n_labels_B]
-    c = p_ij[1:n_labels_A,0].todense()
-    d = np.array(b.todense()) ** 2
-
-    a_i = np.array(a.sum(1))
-    b_i = np.array(b.sum(0))
 
     sumA = np.sum(a_i * a_i)
     sumB = np.sum(b_i * b_i) + (np.sum(c) / n)

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -1002,8 +1002,10 @@ def adapted_rand_error(seg, gt, all_stats=False):
     #sumB = np.sum(b_i * b_i) + (np.sum(c) / n)
     #sumAB = np.sum(d) + (np.sum(c) / n)
 
-    precision = sumAB / sumB
-    recall = sumAB / sumA
+    #precision = sumAB / sumB
+    #recall = sumAB / sumA
+
+    
 
     fScore = 2.0 * precision * recall / (precision + recall)
     are = 1.0 - fScore

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -284,7 +284,7 @@ def contingency_table(seg, gt, *, ignore_seg=(), ignore_gt=(), norm=True):
         labeled `i` in `seg` and `j` in `gt`. (Or the proportion of such voxels
         if `norm=True`.)
     """
-    segr = seg.ravel() 
+    segr = seg.ravel()
     gtr = gt.ravel()
     ignored = np.zeros(segr.shape, np.bool)
     data = np.ones(gtr.shape)
@@ -740,7 +740,7 @@ def vi(x, y=None, weights=np.ones(2), ignore_x=[0], ignore_y=[0]):
 
     References
     ----------
-    [1] Meila, M. (2007). Comparing clusterings - an information based 
+    [1] Meila, M. (2007). Comparing clusterings - an information based
     distance. Journal of Multivariate Analysis 98, 873-895.
     """
     return np.dot(weights, split_vi(x, y, ignore_x, ignore_y))
@@ -786,7 +786,7 @@ def split_vi(x, y=None, ignore_x=[0], ignore_y=[0]):
 def vi_pairwise_matrix(segs, split=False):
     """Compute the pairwise VI distances within a set of segmentations.
 
-    If 'split' is set to True, two matrices are returned, one for each 
+    If 'split' is set to True, two matrices are returned, one for each
     direction of the conditional entropy.
 
     0-labeled pixels are ignored.
@@ -886,7 +886,7 @@ def vi_by_threshold(ucm, gt, ignore_seg=[], ignore_gt=[], npoints=None,
                 for t in ts]
     else:
         p = multiprocessing.Pool(nprocessors)
-        result = p.map(split_vi_threshold, 
+        result = p.map(split_vi_threshold,
             ((ucm, gt, ignore_seg, ignore_gt, t) for t in ts))
     return np.concatenate((ts[np.newaxis, :], np.array(result).T), axis=0)
 
@@ -929,8 +929,8 @@ def rand_by_threshold(ucm, gt, npoints=None):
 def adapted_rand_error(seg, gt, all_stats=False):
     """Compute Adapted Rand error as defined by the SNEMI3D contest [1]
 
-    Formula is given as 1 - the maximal F-score of the Rand index 
-    (excluding the zero component of the original labels). Adapted 
+    Formula is given as 1 - the maximal F-score of the Rand index
+    (excluding the zero component of the original labels). Adapted
     from the SNEMI3D MATLAB script, hence the strange style.
 
     Parameters
@@ -959,6 +959,12 @@ def adapted_rand_error(seg, gt, all_stats=False):
     # segA is truth, segB is query
     segA = np.ravel(gt)
     segB = np.ravel(seg)
+
+    # mask to foreground in A
+    mask = (segA > 0)
+    segA = segA[mask]
+    segB = segB[mask]
+
     n = segA.size
 
     n_labels_A = np.amax(segA) + 1
@@ -985,7 +991,7 @@ def adapted_rand_error(seg, gt, all_stats=False):
 
     fScore = 2.0 * precision * recall / (precision + recall)
     are = 1.0 - fScore
-    
+
     if all_stats:
         return (are, precision, recall)
     else:
@@ -994,15 +1000,15 @@ def adapted_rand_error(seg, gt, all_stats=False):
 
 def calc_entropy(split_vals, count):
     col_count = 0
-    for key, val in split_vals.items(): 
+    for key, val in split_vals.items():
         col_count += val
-    col_prob = float(col_count) / count 
+    col_prob = float(col_count) / count
 
     ent_val = 0
-    for key, val in split_vals.items(): 
+    for key, val in split_vals.items():
         val_norm = float(val)/count
         temp = (val_norm / col_prob)
-        ent_val += temp * np.log2(temp) 
+        ent_val += temp * np.log2(temp)
     return -(col_prob * ent_val)
 
 
@@ -1011,7 +1017,7 @@ def split_vi_mem(x, y):
     y_labels = np.unique(y)
     x_labels0 = x_labels[x_labels != 0]
     y_labels0 = y_labels[y_labels != 0]
- 
+
     x_map = {}
     y_map = {}
 
@@ -1204,10 +1210,10 @@ def sorted_vi_components(s1, s2, ignore1=[0], ignore2=[0], compress=False):
         Labels in these lists are ignored in computing the VI. 0-labels are
         ignored by default; pass empty lists to use all labels.
     compress : bool, optional
-        The 'compress' flag performs a remapping of the labels before doing 
+        The 'compress' flag performs a remapping of the labels before doing
         the VI computation, resulting in memory savings when many labels are
         not used in the volume. (For example, if you have just two labels, 1
-        and 1,000,000, 'compress=False' will give a vector of length 
+        and 1,000,000, 'compress=False' will give a vector of length
         1,000,000, whereas with 'compress=True' it will have just size 2.)
 
     Returns
@@ -1249,7 +1255,7 @@ def split_components(idx, cont, num_elems=4, axis=0):
         The axis along which to perform the calculations. Assuming `cont` has
         the automatic segmentation as the rows and the gold standard as the
         columns, `axis=0` will return the segment IDs in the gold standard of
-        the worst merges comprising `idx`, while `axis=1` will return the 
+        the worst merges comprising `idx`, while `axis=1` will return the
         segment IDs in the automatic segmentation of the worst splits
         comprising `idx`.
 
@@ -1370,7 +1376,7 @@ def fm_index(x, y=None):
 
     References
     ----------
-    [1] EB Fowlkes & CL Mallows. (1983) A method for comparing two 
+    [1] EB Fowlkes & CL Mallows. (1983) A method for comparing two
     hierarchical clusterings. J Am Stat Assoc 78: 553
     """
     cont = x if y is None else contingency_table(x, y, norm=False)
@@ -1415,7 +1421,7 @@ def reduce_vi(fn_pattern='testing/%i/flat-single-channel-tr%i-%i-%.2f.lzf.h5',
                 try:
                     current_vi = np.array(f['vi'])[:, 0]
                 except IOError:
-                    logging.warning('IOError: could not open file %s' 
+                    logging.warning('IOError: could not open file %s'
                         % current_fn)
                 except KeyError:
                     logging.warning('KeyError: could not find vi in file %s'

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -979,14 +979,14 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
 
     p_ij = sparse.csr_matrix((ones_data, (segA[:], segB[:])), shape=(n_labels_A, n_labels_B), dtype=np.uint64)
 
-    # In the paper where adapted rand is proposed, they treat each background
+    # In the paper where adapted rand error is proposed, they treat each background
     # pixel in segB as a different value (i.e., unique label for each pixel).
-    # To do this, we sum them differently than others
+    # To do this, we sum them differently than others.
 
     B_nonzero = p_ij[:, 1:]
     B_zero = p_ij[:, 0]
 
-    # this is a count
+    # This is a count of pixels labelled a zero in segment B.
     num_B_zero = B_zero.sum()
 
     # This is the new code, removing the divides by n because they cancel.
@@ -1008,13 +1008,13 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
         sum_b = np.power(b_i, 2).sum() + num_B_zero
 
     # This is old code no longer required for this version of the adapted
-    # Rand error. It has been commented out
-    #sumA = np.sum(a_i * a_i)
-    #sumB = np.sum(b_i * b_i) + (np.sum(c) / n)
-    #sumAB = np.sum(d) + (np.sum(c) / n)
+    # Rand error. It has been commented out.
+    # sumA = np.sum(a_i * a_i)
+    # sumB = np.sum(b_i * b_i) + (np.sum(c) / n)
+    # sumAB = np.sum(d) + (np.sum(c) / n)
 
-    #precision = sumAB / sumB
-    #recall = sumAB / sumA
+    # precision = sumAB / sumB
+    # recall = sumAB / sumA
 
     precision = float(sum_p_ij) / sum_b
     recall = float(sum_p_ij) / sum_a

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -953,7 +953,7 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
         The adapted Rand recall.  (Only returned when `all_stats` is ``True``.)
     count_zeros : boolean, optional
         Formal parameter that includes the calculation of background pixels
-        labeled a zero in the ARE (enabled by default)
+        labeled a zero in the ARE (set True by default)
 
     References
     ----------
@@ -997,7 +997,10 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
     b_i = B_nonzero.sum(0)
 
     sum_a = np.power(a_i, 2).sum()
-    sum_b = np.power(b_i, 2).sum() + num_B_zero
+    if count_zeros is False:
+        sum_b = np.power(b_i, 2).sum()
+    else:
+        sum_b = np.power(b_i, 2).sum() + num_B_zero
 
     # This is old code no longer required for this version of the adapted
     # Rand error. It has been commented out

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -926,7 +926,7 @@ def rand_by_threshold(ucm, gt, npoints=None):
         result[1, i] = adj_rand_index(seg, gt)
     return np.concatenate((ts[np.newaxis, :], result), axis=0)
 
-def adapted_rand_error(seg, gt, all_stats=False, count_zeros=False):
+def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
     """Compute Adapted Rand error as defined by the SNEMI3D contest [1]
 
     Formula is given as 1 - the maximal F-score of the Rand index
@@ -953,7 +953,7 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=False):
         The adapted Rand recall.  (Only returned when `all_stats` is ``True``.)
     count_zeros : boolean, optional
         Formal parameter that includes the calculation of background pixels
-        labeled a zero in the ARE (disabled by default)
+        labeled a zero in the ARE (enabled by default)
 
     References
     ----------

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -989,6 +989,10 @@ def adapted_rand_error(seg, gt, all_stats=False):
     # sum of the joint distribution ,separate sum of B>0 and B=0 parts
     sum_p_ij = (B_nonzero).power(2).sum() + num_B_zero
 
+    # these are marginal probabilities
+    a_i = p_ij.sum(1)
+    b_i = B_nonzero.sum(0)
+
     a = p_ij[1:n_labels_A,:]
     b = p_ij[1:n_labels_A,1:n_labels_B]
     c = p_ij[1:n_labels_A,0].todense()

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -926,7 +926,7 @@ def rand_by_threshold(ucm, gt, npoints=None):
         result[1, i] = adj_rand_index(seg, gt)
     return np.concatenate((ts[np.newaxis, :], result), axis=0)
 
-def adapted_rand_error(seg, gt, all_stats=False):
+def adapted_rand_error(seg, gt, all_stats=False, count_zeros=False):
     """Compute Adapted Rand error as defined by the SNEMI3D contest [1]
 
     Formula is given as 1 - the maximal F-score of the Rand index

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -942,7 +942,7 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
     all_stats : boolean, optional
         whether to also return precision and recall as a 3-tuple with rand_error
     count_zeros : boolean, optional
-        whether to include the pixels labeled a zero in the groundtruth or not
+        whether to include the pixels labeled a zero in the segment B or not
 
     Returns
     -------
@@ -999,8 +999,11 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
     b_i = B_nonzero.sum(0)
 
     sum_a = np.power(a_i, 2).sum()
+    # If user has explicitly set parameter to false, then non-zero
+    # pixels in seg B labeled a zero will not be included.
     if count_zeros is False:
         sum_b = np.power(b_i, 2).sum()
+    # Otherwise, include the non-zero pixels found in seg B in calculation.
     else:
         sum_b = np.power(b_i, 2).sum() + num_B_zero
 

--- a/gala/evaluate.py
+++ b/gala/evaluate.py
@@ -954,8 +954,9 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
     rec : float, optional
         The adapted Rand recall.  (Only returned when `all_stats` is ``True``.)
     count_zeros : boolean, optional
-        Formal parameter that includes the calculation of background pixels
-        labeled a zero in the ARE (set True by default)
+        Formal parameter that sets whether to include the calculation of
+        background pixels labeled a zero in the segment or not
+        (set True by default)
 
     References
     ----------
@@ -999,8 +1000,8 @@ def adapted_rand_error(seg, gt, all_stats=False, count_zeros=True):
     b_i = B_nonzero.sum(0)
 
     sum_a = np.power(a_i, 2).sum()
-    # If user has explicitly set parameter to false, then non-zero
-    # pixels in seg B labeled a zero will not be included.
+    # If user has explicitly set the count_zeros parameter to false, then
+    # non-zero pixels in seg B labeled a zero will not be included.
     if count_zeros is False:
         sum_b = np.power(b_i, 2).sum()
     # Otherwise, include the non-zero pixels found in seg B in calculation.

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -21,6 +21,6 @@ def test_vi():
     assert_equal(ev.vi(seg, gt), 1)
 
 def test_are():
-    seg = np.array([[0, 1], [1, 0]])
-    gt = np.array([[1, 2],[0, 1]])
+    seg = np.array([[2, 1], [1, 2]])
+    gt = np.array([[1, 2],[3, 1]])
     assert_almost_equal((ev.adapted_rand_error(seg, gt)), 0.3333333)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -21,7 +21,7 @@ def test_vi():
     assert_equal(ev.vi(seg, gt), 1)
 
 def test_are():
-    seg = np.eye(3)
-    gt = np.eye(3)
-    seg[1][1] = 0
+    seg = np.array([[0,1], [1,0]])
+    gt = np.array([[1,2],[0,1]])
+    assert_almost_equal(ev.adapted_rand_error(seg,gt),0.081)
     assert seg.shape == gt.shape

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -19,3 +19,9 @@ def test_vi():
     seg = np.array([1, 2, 3, 4])
     gt = np.array([1, 1, 8, 8])
     assert_equal(ev.vi(seg, gt), 1)
+
+def test_are():
+    seg = np.eye(3)
+    gt = np.eye(3)
+    seg[1][1] = 0
+    assert seg.shape == gt.shape

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_almost_equal
 from gala import evaluate as ev
 
 def test_contingency_table():

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -23,5 +23,5 @@ def test_vi():
 def test_are():
     seg = np.array([[0,1], [1,0]])
     gt = np.array([[1,2],[0,1]])
-    assert_almost_equal(ev.adapted_rand_error(seg,gt),0.081)
+    assert_almost_equal(abs(ev.adapted_rand_error(seg,gt)),0.33)
     assert seg.shape == gt.shape

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -21,7 +21,6 @@ def test_vi():
     assert_equal(ev.vi(seg, gt), 1)
 
 def test_are():
-    seg = np.array([[0,1], [1,0]])
-    gt = np.array([[1,2],[0,1]])
-    assert_almost_equal(abs(ev.adapted_rand_error(seg,gt)),0.3333333)
-    assert seg.shape == gt.shape
+    seg = np.array([[0, 1], [1, 0]])
+    gt = np.array([[1, 2],[0, 1]])
+    assert_almost_equal((ev.adapted_rand_error(seg, gt)), 0.3333333)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -23,5 +23,5 @@ def test_vi():
 def test_are():
     seg = np.array([[0,1], [1,0]])
     gt = np.array([[1,2],[0,1]])
-    assert_almost_equal(abs(ev.adapted_rand_error(seg,gt)),0.33)
+    assert_almost_equal(abs(ev.adapted_rand_error(seg,gt)),0.3333333)
     assert seg.shape == gt.shape


### PR DESCRIPTION
As per discussion at https://github.com/cremi/cremi_python/issues/3#issuecomment-241711193 about errors with the normalisation of the Adapted Rand Errror, I have incorporated the changes to the ARE, adapted from the fixed code found in the above discussion, which is seen in the link: https://gist.github.com/thouis/63888c375cbeb2f702e94e2e82eebee8. 
The main change to the code is the removal of the division by 'n' , which previously had included division by both zero and non-zero pixels, which occurred when calculating the sum of the pixels in segments A and B. So now this code reflects only division by non-zero pixels, which is what should have been reflected in the reference implementation. 

