### PR TITLE
Include tests for image_type

### DIFF
--- a/gala/viz.py
+++ b/gala/viz.py
@@ -95,6 +95,10 @@ def show_multiple_images(*images, axes=None, image_type='raw'):
     fig : plt.Figure
         The image shown.
     """
+    if image_type not in ["raw", "rand", "gray", "grey", "magma"]:
+        raise LookupError("image_type only understands 'raw', 'rand', \
+                          'gray', 'grey' or 'magma'. You entered '{}'.".
+                          format(image_type))
     number_of_im = len(images)
     figure = plt.figure()
     for i in range(number_of_im):


### PR DESCRIPTION
Put in a test for the function 'viz.show_multiple_images' to ensure that the 'image_type' parameter has sane output