### PR TITLE
Package miscellaneous files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,8 @@
 recursive-include gala *.pxd *.pyx *.pxi
+
+CITATION.bib
+CITATION.md
+
+LICENSE.txt
+
+README.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include gala *.pyx
+recursive-include gala *.pxd *.pyx *.pxi


### PR DESCRIPTION
Includes a few files left out of (or potentially left out of) the `sdist`.